### PR TITLE
feat: add CLI flags for role-specific model and permission settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,25 +35,25 @@ bun test src/lib/config.spec.ts
 ### CLI Usage
 ```bash
 # Initialize tmux session with 3 Claude Code instances (generates unique session name)
-ccteam start
+npx ccteam@latest start
 
 # Start with custom configuration file
-ccteam start -c path/to/config.yml
+npx ccteam@latest start -c path/to/config.yml
 
 # Start with CLI flags overriding configuration
-ccteam start --manager-model opus --worker-skip-permissions
+npx ccteam@latest start --manager-model opus --worker-skip-permissions
 
 # Create default configuration file
-ccteam init
+npx ccteam@latest init
 
 # Create configuration file at custom path
-ccteam init -c path/to/config.yml
+npx ccteam@latest init -c path/to/config.yml
 
 # Send message to specific role (for agents only)
-ccteam send <role> <message>  # role: manager|leader|worker
+npx ccteam@latest send <role> <message>  # role: manager|leader|worker
 
 # Delete processed message files (for agents only)
-ccteam messages delete <message-file>
+npx ccteam@latest messages delete <message-file>
 ```
 
 ### CLI Flags for Start Command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ bun test src/lib/config.spec.ts
 # Initialize tmux session with 3 Claude Code instances (generates unique session name)
 ccteam start
 
+# Start with custom configuration file
+ccteam start -c path/to/config.yml
+
+# Start with CLI flags overriding configuration
+ccteam start --manager-model opus --worker-skip-permissions
+
 # Create default configuration file
 ccteam init
 
@@ -49,6 +55,15 @@ ccteam send <role> <message>  # role: manager|leader|worker
 # Delete processed message files (for agents only)
 ccteam messages delete <message-file>
 ```
+
+### CLI Flags for Start Command
+The `start` command supports flags to override configuration file settings:
+- `--manager-model <string>`: Manager role model
+- `--manager-skip-permissions`: Manager role skip permissions
+- `--leader-model <string>`: Leader role model
+- `--leader-skip-permissions`: Leader role skip permissions
+- `--worker-model <string>`: Worker role model
+- `--worker-skip-permissions`: Worker role skip permissions
 
 ## Architecture
 
@@ -84,6 +99,8 @@ ccteam messages delete <message-file>
 **Configuration System**:
 - Configuration files use YAML format with Zod validation
 - `loadConfig()` function handles file reading and parsing with error checking
+- CLI flags override configuration file settings when provided
+- Explicitly specified config files (via --config) must exist or an error is thrown
 - Default configuration logic is handled in the `start` command for better separation of concerns
 - File overwrite protection prevents accidental configuration loss
 
@@ -109,10 +126,11 @@ ccteam messages delete <message-file>
 - **Testing Framework**: Bun's built-in test runner with `.spec.ts` files
 
 ### Important Constraints
-- Never use `tmux send-keys` directly - always use `bun run ./src/main.ts send`
-- Never use `rm` to delete message files - always use `bun run ./src/main.ts messages delete`
+- Never use `tmux send-keys` directly - always use `bun run ./src/main.ts send` or `npx ccteam@latest send`
+- Never use `rm` to delete message files - always use `bun run ./src/main.ts messages delete` or `npx ccteam@latest messages delete`
 - Tmux operations must use the `tmux()` wrapper in `lib/tmux.ts`
 - All role instructions are embedded in the binary from `src/instructions/*.md`
+- The `start` function requires a StartOptions object (not optional)
 
 ## Project Structure
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ The `start` command supports flags to override configuration file settings:
 **Command Structure**:
 - Commands are implemented in `src/cmd/{command-name}/index.ts`
 - All commands are async functions with typed parameters
-- Commands can import and reuse other commands (e.g., `start` uses `send`)
+- Commands can import and reuse other commands (e.g. `start` uses `send`)
 
 **Error Handling**:
 - Early validation with clear error messages

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>koki-develop/renovate-config"]
+}

--- a/src/cmd/start/index.ts
+++ b/src/cmd/start/index.ts
@@ -14,6 +14,16 @@ import { tmux } from "../../lib/tmux";
 import { generateSessionName, sleep } from "../../lib/util";
 import { send } from "../send";
 
+interface StartOptions {
+  config?: string;
+  managerModel?: string;
+  managerSkipPermissions?: boolean;
+  leaderModel?: string;
+  leaderSkipPermissions?: boolean;
+  workerModel?: string;
+  workerSkipPermissions?: boolean;
+}
+
 function buildClaudeCommand(roleConfig: RoleConfig): string[] {
   const command = ["claude"];
 
@@ -28,13 +38,13 @@ function buildClaudeCommand(roleConfig: RoleConfig): string[] {
   return command;
 }
 
-export async function start(configPath?: string) {
+export async function start(options: StartOptions) {
   console.log("[INFO] Starting ccteam initialization...");
 
-  if (configPath && configPath !== "ccteam.yml") {
-    console.log(`[INFO] Using config file: ${configPath}`);
+  if (options.config) {
+    console.log(`[INFO] Using config file: ${options.config}`);
   }
-  const config = _loadConfig(configPath);
+  const config = _loadConfig(options);
 
   const session = generateSessionName();
   await tmux(
@@ -151,23 +161,90 @@ function showAttachInstructions(session: string) {
   console.log("=".repeat(60));
 }
 
-function _loadConfig(configPath?: string): Config {
-  const targetPath = (() => {
-    if (configPath) {
-      return path.resolve(process.cwd(), configPath);
-    }
-    return path.resolve(process.cwd(), "ccteam.yml");
-  })();
+function _loadConfig(options: StartOptions): Config {
+  const { config: configPath, ...cliOptions } = options;
 
-  if (!configPath && !fs.existsSync(targetPath)) {
+  const resolvedConfigPath = path.resolve(
+    process.cwd(),
+    configPath ?? "ccteam.yml",
+  );
+
+  if (fs.existsSync(resolvedConfigPath)) {
+    const fileConfig = loadConfig(resolvedConfigPath);
     return {
       roles: {
-        manager: { skipPermissions: false },
-        leader: { skipPermissions: false },
-        worker: { skipPermissions: false },
+        manager: {
+          ...fileConfig.roles.manager,
+          ...(cliOptions.managerModel != null && {
+            model: cliOptions.managerModel,
+          }),
+          ...(cliOptions.managerSkipPermissions != null && {
+            skipPermissions: cliOptions.managerSkipPermissions,
+          }),
+        },
+        leader: {
+          ...fileConfig.roles.leader,
+          ...(cliOptions.leaderModel != null && {
+            model: cliOptions.leaderModel,
+          }),
+          ...(cliOptions.leaderSkipPermissions != null && {
+            skipPermissions: cliOptions.leaderSkipPermissions,
+          }),
+        },
+        worker: {
+          ...fileConfig.roles.worker,
+          ...(cliOptions.workerModel != null && {
+            model: cliOptions.workerModel,
+          }),
+          ...(cliOptions.workerSkipPermissions != null && {
+            skipPermissions: cliOptions.workerSkipPermissions,
+          }),
+        },
       },
     };
   }
 
-  return loadConfig(targetPath);
+  if (configPath) {
+    throw new Error(`Configuration file not found: ${configPath}`);
+  }
+
+  const defaultConfig: Config = {
+    roles: {
+      manager: { skipPermissions: false },
+      leader: { skipPermissions: false },
+      worker: { skipPermissions: false },
+    },
+  };
+
+  return {
+    roles: {
+      manager: {
+        ...defaultConfig.roles.manager,
+        ...(cliOptions.managerModel != null && {
+          model: cliOptions.managerModel,
+        }),
+        ...(cliOptions.managerSkipPermissions != null && {
+          skipPermissions: cliOptions.managerSkipPermissions,
+        }),
+      },
+      leader: {
+        ...defaultConfig.roles.leader,
+        ...(cliOptions.leaderModel != null && {
+          model: cliOptions.leaderModel,
+        }),
+        ...(cliOptions.leaderSkipPermissions != null && {
+          skipPermissions: cliOptions.leaderSkipPermissions,
+        }),
+      },
+      worker: {
+        ...defaultConfig.roles.worker,
+        ...(cliOptions.workerModel != null && {
+          model: cliOptions.workerModel,
+        }),
+        ...(cliOptions.workerSkipPermissions != null && {
+          skipPermissions: cliOptions.workerSkipPermissions,
+        }),
+      },
+    },
+  };
 }

--- a/src/cmd/start/index.ts
+++ b/src/cmd/start/index.ts
@@ -88,7 +88,7 @@ export async function start(options: StartOptions) {
   await setupInstructions(session);
   await setupManager(session, config);
   await setupLeader(session, config);
-  await setupEditor(session, config);
+  await setupWorker(session, config);
   console.log("[INFO] All roles initialized");
 
   showAttachInstructions(session);
@@ -140,7 +140,7 @@ Please read @.ccteam/${session}/instructions/leader.md and understand your role.
   await send({ session, role: "leader", message: prompt });
 }
 
-async function setupEditor(session: string, config: Config) {
+async function setupWorker(session: string, config: Config) {
   const command = buildClaudeCommand(config.roles.worker);
   await send({ session, role: "worker", message: command.join(" ") });
   await sleep(3000);

--- a/src/instructions/manager.md
+++ b/src/instructions/manager.md
@@ -56,9 +56,9 @@ Please use the following template:
 (Include if applicable)
 
 ## Expected Deliverables
-- Deliverable 1 (e.g., implemented code)
-- Deliverable 2 (e.g., test files)
-- Deliverable 3 (e.g., documentation)
+- Deliverable 1 (e.g. implemented code)
+- Deliverable 2 (e.g. test files)
+- Deliverable 3 (e.g. documentation)
 
 ## Notes
 (Include special notes or important points if applicable)

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,13 +20,31 @@ program
   .description(
     "Initialize tmux session with 3 Claude Code instances (Manager/Leader/Worker)",
   )
-  .option("-c, --config <path>", "Configuration file path")
-  .option("--manager-model <string>", "Manager role model")
-  .option("--manager-skip-permissions", "Manager role skip permissions")
-  .option("--leader-model <string>", "Leader role model")
-  .option("--leader-skip-permissions", "Leader role skip permissions")
-  .option("--worker-model <string>", "Worker role model")
-  .option("--worker-skip-permissions", "Worker role skip permissions")
+  .option("-c, --config <path>", "Path to configuration file")
+  .option(
+    "--manager-model <string>",
+    "Claude model for Manager role (e.g. opus, sonnet, haiku)",
+  )
+  .option(
+    "--manager-skip-permissions",
+    "Skip permission prompts for Manager role's Claude Code instance",
+  )
+  .option(
+    "--leader-model <string>",
+    "Claude model for Leader role (e.g. opus, sonnet, haiku)",
+  )
+  .option(
+    "--leader-skip-permissions",
+    "Skip permission prompts for Leader role's Claude Code instance",
+  )
+  .option(
+    "--worker-model <string>",
+    "Claude model for Worker role (e.g. opus, sonnet, haiku)",
+  )
+  .option(
+    "--worker-skip-permissions",
+    "Skip permission prompts for Worker role's Claude Code instance",
+  )
   .action(async (options) => {
     await start(options);
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,14 @@ program
     "Initialize tmux session with 3 Claude Code instances (Manager/Leader/Worker)",
   )
   .option("-c, --config <path>", "Configuration file path")
+  .option("--manager-model <string>", "Manager role model")
+  .option("--manager-skip-permissions", "Manager role skip permissions")
+  .option("--leader-model <string>", "Leader role model")
+  .option("--leader-skip-permissions", "Leader role skip permissions")
+  .option("--worker-model <string>", "Worker role model")
+  .option("--worker-skip-permissions", "Worker role skip permissions")
   .action(async (options) => {
-    await start(options.config);
+    await start(options);
   });
 
 program


### PR DESCRIPTION
## Summary

This PR introduces CLI flags to the `start` command that allow users to override role-specific settings directly from the command line, providing greater flexibility without requiring configuration file modifications.

## Changes

### New CLI Flags
Added six new flags to the `start` command:
- `--manager-model <string>`: Specify the Claude model for the Manager role
- `--manager-skip-permissions`: Skip permission prompts for the Manager role
- `--leader-model <string>`: Specify the Claude model for the Leader role
- `--leader-skip-permissions`: Skip permission prompts for the Leader role
- `--worker-model <string>`: Specify the Claude model for the Worker role
- `--worker-skip-permissions`: Skip permission prompts for the Worker role

### Implementation Details

1. **Enhanced Start Command Interface**
   - Modified the `start` function to accept a `StartOptions` object instead of a simple string
   - This allows for structured passing of multiple configuration options

2. **Configuration Override Logic**
   - Refactored `_loadConfig` function to implement a clear priority hierarchy:
     1. CLI flags (highest priority)
     2. Configuration file settings
     3. Default values (lowest priority)
   - Used spread syntax and conditional object properties for clean configuration merging

3. **Improved Error Handling**
   - Added validation to ensure explicitly specified config files exist
   - Provides clear error messages when config files are not found

4. **Code Quality Improvements**
   - Simplified the configuration loading logic using early return pattern
   - Fixed boolean flag handling to properly process `false` values using `\!= null` checks
   - Removed unnecessary type unions and complexity

## Usage Examples

```bash
# Use specific models for different roles
npx ccteam@latest start --manager-model haiku --leader-model sonnet --worker-model opus

# Skip permissions for specific roles
npx ccteam@latest start --manager-skip-permissions --worker-skip-permissions

# Combine with custom config file
npx ccteam@latest start -c custom.yml --worker-model opus

# Override all settings via CLI
npx ccteam@latest start \
  --manager-model haiku --manager-skip-permissions \
  --leader-model sonnet --leader-skip-permissions \
  --worker-model opus --worker-skip-permissions
```

## Benefits

- **Flexibility**: Users can quickly test different model configurations without editing files
- **Convenience**: Override specific settings for one-off runs or experiments
- **Compatibility**: Maintains backward compatibility with existing configuration files
- **Clarity**: CLI flags provide clear, self-documenting options

## Testing

- All existing functionality remains intact
- TypeScript type checking passes
- Biome linting passes
- Configuration priority (CLI > file > default) works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)