### PR TITLE
feat: add tmux installation check on start command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,16 @@ npx ccteam@latest agent messages delete <message-file>
 The `start` command supports flags to override configuration file settings:
 - `--manager-model <string>`: Manager role model
 - `--manager-skip-permissions`: Manager role skip permissions
+- `--manager-allowed-tools <string>`: Manager role allowed tools (comma-separated list)
+- `--manager-disallowed-tools <string>`: Manager role disallowed tools (comma-separated list)
 - `--leader-model <string>`: Leader role model
 - `--leader-skip-permissions`: Leader role skip permissions
+- `--leader-allowed-tools <string>`: Leader role allowed tools (comma-separated list)
+- `--leader-disallowed-tools <string>`: Leader role disallowed tools (comma-separated list)
 - `--worker-model <string>`: Worker role model
 - `--worker-skip-permissions`: Worker role skip permissions
+- `--worker-allowed-tools <string>`: Worker role allowed tools (comma-separated list)
+- `--worker-disallowed-tools <string>`: Worker role disallowed tools (comma-separated list)
 
 ## Architecture
 
@@ -93,11 +99,12 @@ The `start` command supports flags to override configuration file settings:
 - Early validation with clear error messages
 - File existence checks before operations
 - Automatic directory creation with `{ recursive: true }`
+- Throws errors for upper-level handling (no process.exit in library code)
 
 **Logging Convention**:
-- Use `[INFO]` prefix for all console logs
-- Progress messages for multi-step operations
-- Decorative completion messages with emoji and separators
+- Use `[INFO]` prefix for all console logs with chalk.blue
+- Progress messages use ora spinners
+- Decorative completion messages with boxen for important output
 
 **Configuration System**:
 - Configuration files use YAML format with Zod validation
@@ -128,6 +135,7 @@ The `start` command supports flags to override configuration file settings:
 - **Release Management**: Release Please for automated releases
 - **Testing Framework**: Bun's built-in test runner with `.spec.ts` files
 - **CI/CD**: GitHub Actions with lint and build jobs
+- **Styling**: chalk (colors), ora (spinners), boxen (boxes)
 
 ### Important Constraints
 - Never use `tmux send-keys` directly - always use `bun run ./src/main.ts agent send` or `npx ccteam@latest agent send`
@@ -135,6 +143,7 @@ The `start` command supports flags to override configuration file settings:
 - Tmux operations must use the `tmux()` wrapper in `lib/tmux.ts`
 - All role instructions are embedded in the binary from `src/instructions/*.md`
 - The `start` function requires a StartOptions object (not optional)
+- Tmux installation is checked before starting sessions using `command-exists` package
 
 ## Project Structure
 ```
@@ -147,7 +156,7 @@ src/
 ├── instructions/        # Role-specific instruction documents
 ├── lib/                 # Shared utilities
 │   ├── config.ts        # Configuration loading and validation
-│   ├── tmux.ts          # tmux command wrapper
+│   ├── tmux.ts          # tmux command wrapper and installation check
 │   └── util.ts          # General utilities (sleep, session management, etc.)
 └── types/               # TypeScript type definitions
 ```
@@ -160,3 +169,5 @@ src/
 - Test files should use `*.spec.ts` naming convention and be placed alongside implementation files
 - Bun dependencies are installed with exact versions (configured in `bunfig.toml`)
 - When publishing to npm, the build runs automatically via `prepublishOnly` hook
+- Biome configuration enforces double quotes for JavaScript/TypeScript strings
+- Tool configuration (allowed/disallowed tools) can be specified per role for enhanced security

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "boxen": "8.0.1",
         "chalk": "5.4.1",
+        "command-exists": "1.2.9",
         "commander": "14.0.0",
         "ora": "8.2.0",
         "yaml": "2.8.0",
@@ -14,6 +15,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.16",
+        "@types/command-exists": "1.2.3",
         "husky": "9.1.7",
         "lint-staged": "16.1.2",
         "typescript": "5.8.3",
@@ -40,6 +42,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@types/bun": ["@types/bun@1.2.16", "", { "dependencies": { "bun-types": "1.2.16" } }, "sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ=="],
+
+    "@types/command-exists": ["@types/command-exists@1.2.3", "", {}, "sha512-PpbaE2XWLaWYboXD6k70TcXO/OdOyyRFq5TVpmlUELNxdkkmXU9fkImNosmXU1DtsNrqdUgWd/nJQYXgwmtdXQ=="],
 
     "@types/node": ["@types/node@24.0.3", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg=="],
 
@@ -70,6 +74,8 @@
     "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "command-exists": ["command-exists@1.2.9", "", {}, "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="],
 
     "commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "boxen": "8.0.1",
     "chalk": "5.4.1",
+    "command-exists": "1.2.9",
     "commander": "14.0.0",
     "ora": "8.2.0",
     "yaml": "2.8.0",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.2.16",
+    "@types/command-exists": "1.2.3",
     "husky": "9.1.7",
     "lint-staged": "16.1.2",
     "typescript": "5.8.3"

--- a/src/cmd/start/index.ts
+++ b/src/cmd/start/index.ts
@@ -13,7 +13,7 @@ import workerInstruction from "../../instructions/worker.md" with {
   type: "text",
 };
 import { type Config, type RoleConfig, loadConfig } from "../../lib/config";
-import { send, tmux } from "../../lib/tmux";
+import { isTmuxInstalled, send, tmux } from "../../lib/tmux";
 import { generateSessionName, quote, sleep } from "../../lib/util";
 
 interface StartOptions {
@@ -59,6 +59,13 @@ export function buildClaudeCommand(roleConfig: RoleConfig): string[] {
 
 export async function startCommand(options: StartOptions) {
   console.log(`${chalk.blue("[INFO]")} Starting ccteam initialization...`);
+
+  const tmuxCheckSpinner = ora("Checking tmux installation...").start();
+  if (!isTmuxInstalled()) {
+    tmuxCheckSpinner.fail("tmux check failed");
+    throw new Error("tmux is not installed");
+  }
+  tmuxCheckSpinner.succeed("tmux is installed");
 
   if (options.config) {
     console.log(`${chalk.blue("[INFO]")} Using config file: ${options.config}`);

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { sync as commandExists } from "command-exists";
 import { sleep } from "./util";
 
 export function tmux(...args: string[]): Promise<string> {
@@ -45,4 +46,8 @@ export async function send({ session, role, message }: SendParams) {
   await tmux("send-keys", "-t", target, message);
   await sleep(1000);
   await tmux("send-keys", "-t", target, "C-m");
+}
+
+export function isTmuxInstalled(): boolean {
+  return commandExists("tmux");
 }


### PR DESCRIPTION
## Summary
- Add tmux installation check before initializing sessions
- Show clear error message when tmux is not installed
- Use `command-exists` package for cross-platform compatibility

## Motivation
Previously, the `start` command would fail with an unclear error message if tmux was not installed. This change adds an explicit check with a user-friendly error message.

## Changes
- Add `isTmuxInstalled()` function using `command-exists` package
- Check tmux installation at the beginning of `start` command
- Show spinner during check and clear error message on failure

## Test plan
- [x] Verify that the command works correctly when tmux is installed
- [ ] Test error message when tmux is not installed
- [ ] Confirm cross-platform compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)