### PR TITLE
feat: Add list command for session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,26 @@ The Manager will delegate tasks to the Leader, who will create specifications fo
 
 That's it! Your AI team will handle the rest, from planning to implementation.
 
-### 6. **Stop a team session:**
+### 6. **View active sessions:**
+
+You can see all active Claude Code Team sessions at any time:
+
+```console
+$ npx ccteam@latest list
+```
+
+This shows a table with session names, start times, and working directories:
+
+```console
+SESSION           STARTED AT           WORKING DIRECTORY
+────────────────────────────────────────────────────────────────────────────────
+ccteam-abc12      2025-06-24 14:30     /path/to/project-1
+ccteam-def34      2025-06-24 15:45     /path/to/project-2
+
+Found 2 active session(s)
+```
+
+### 7. **Stop a team session:**
 
 When you're done with your Claude Code Team session, you can cleanly stop it using:
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "chalk": "5.4.1",
         "command-exists": "1.2.9",
         "commander": "14.0.0",
+        "date-fns": "4.1.0",
         "ora": "8.2.0",
         "yaml": "2.8.0",
         "zod": "3.25.67",
@@ -78,6 +79,8 @@
     "command-exists": ["command-exists@1.2.9", "", {}, "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="],
 
     "commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "5.4.1",
     "command-exists": "1.2.9",
     "commander": "14.0.0",
+    "date-fns": "4.1.0",
     "ora": "8.2.0",
     "yaml": "2.8.0",
     "zod": "3.25.67"

--- a/src/cmd/list/index.ts
+++ b/src/cmd/list/index.ts
@@ -1,20 +1,12 @@
 import chalk from "chalk";
 import { format } from "date-fns";
-import ora from "ora";
-import { log } from "../../lib/log";
 import { SessionManager } from "../../lib/session";
 
 type ListOptions = Record<string, never>;
 
 export async function listCommand(_options: ListOptions): Promise<void> {
-  log("info", "Loading ccteam sessions...");
-
-  const spinner = ora("Checking active sessions...").start();
-
   const sessionManager = new SessionManager();
   const activeSessions = await sessionManager.listSessions();
-
-  spinner.succeed("Session check completed");
 
   if (activeSessions.length === 0) {
     console.log(chalk.gray("No active ccteam sessions found."));

--- a/src/cmd/list/index.ts
+++ b/src/cmd/list/index.ts
@@ -1,0 +1,49 @@
+import chalk from "chalk";
+import { format } from "date-fns";
+import ora from "ora";
+import { log } from "../../lib/log";
+import { SessionManager } from "../../lib/session";
+
+type ListOptions = Record<string, never>;
+
+export async function listCommand(_options: ListOptions): Promise<void> {
+  log("info", "Loading ccteam sessions...");
+
+  const spinner = ora("Checking active sessions...").start();
+
+  const sessionManager = new SessionManager();
+  const activeSessions = await sessionManager.listSessions();
+
+  spinner.succeed("Session check completed");
+
+  if (activeSessions.length === 0) {
+    console.log(chalk.gray("No active ccteam sessions found."));
+    return;
+  }
+
+  // Display header
+  console.log();
+  console.log(
+    chalk.bold("SESSION           STARTED AT           WORKING DIRECTORY"),
+  );
+  // Display separator line adapted to terminal width
+  const terminalWidth = process.stdout.columns || 80;
+  console.log(chalk.gray("─".repeat(terminalWidth)));
+
+  // Display session information
+  for (const sessionInfo of activeSessions) {
+    const startedAt = format(
+      new Date(sessionInfo.startedAt),
+      "yyyy-MM-dd HH:mm",
+    );
+
+    const nameCol = chalk.cyan(sessionInfo.sessionName.padEnd(17));
+    const timeCol = startedAt.padEnd(20);
+    const dirCol = sessionInfo.workingDirectory;
+
+    console.log(`${nameCol} ${timeCol} ${dirCol}`);
+  }
+
+  console.log();
+  console.log(chalk.gray(`Found ${activeSessions.length} active session(s)`));
+}

--- a/src/cmd/list/index.ts
+++ b/src/cmd/list/index.ts
@@ -14,7 +14,6 @@ export async function listCommand(_options: ListOptions): Promise<void> {
   }
 
   // Display header
-  console.log();
   console.log(
     chalk.bold("SESSION           STARTED AT           WORKING DIRECTORY"),
   );

--- a/src/cmd/start/index.ts
+++ b/src/cmd/start/index.ts
@@ -6,6 +6,7 @@ import { CCTeam } from "../../lib/ccteam";
 import { type Config, loadConfig } from "../../lib/config";
 import { CCTeamError } from "../../lib/error";
 import { log } from "../../lib/log";
+import { SessionManager } from "../../lib/session";
 import { generateSessionName, toast } from "../../lib/util";
 
 interface StartOptions {
@@ -48,6 +49,10 @@ export async function startCommand(options: StartOptions) {
   const prepareSpinner = ora("Preparing tmux session...").start();
   await ccteam.prepareSession();
   prepareSpinner.succeed(`Tmux session created: ${chalk.cyan(session)}`);
+
+  // Save session info
+  const sessionManager = new SessionManager();
+  await sessionManager.saveSession(session, process.cwd());
 
   // Setup roles
   ccteam.prepareInstructions();

--- a/src/cmd/stop/index.ts
+++ b/src/cmd/stop/index.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import { CCTeam } from "../../lib/ccteam";
 import { CCTeamError } from "../../lib/error";
 import { log } from "../../lib/log";
+import { SessionManager } from "../../lib/session";
 import { Tmux } from "../../lib/tmux";
 import { sleep, toast } from "../../lib/util";
 
@@ -52,6 +53,10 @@ export async function stopCommand(session: string): Promise<void> {
   if (fs.existsSync(sessionDir)) {
     fs.rmSync(sessionDir, { recursive: true, force: true });
   }
+
+  // Remove session info
+  const sessionManager = new SessionManager();
+  await sessionManager.deleteSession(session).catch(() => {});
 
   // Completion message
   toast({

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import { Tmux } from "./tmux";
+
+// Session information schema definition
+export const SessionInfoSchema = z.object({
+  sessionName: z.string(),
+  startedAt: z.string(), // ISO 8601 format
+  workingDirectory: z.string(),
+});
+
+export type SessionInfo = z.infer<typeof SessionInfoSchema>;
+
+export class SessionManager {
+  private readonly _tmux: Tmux;
+  private readonly _sessionsDir: string;
+
+  constructor() {
+    this._tmux = new Tmux();
+    this._sessionsDir = path.join(os.homedir(), ".ccteam", "sessions");
+  }
+
+  // Save session (for start command)
+  async saveSession(
+    sessionName: string,
+    workingDirectory: string,
+  ): Promise<void> {
+    this._prepareSessionsDir();
+
+    const sessionInfo: SessionInfo = {
+      sessionName,
+      startedAt: new Date().toISOString(),
+      workingDirectory,
+    };
+
+    const filePath = this._getSessionPath(sessionName);
+    const jsonData = JSON.stringify(sessionInfo, null, 2);
+
+    fs.writeFileSync(filePath, jsonData, "utf8");
+  }
+
+  // Delete session (for stop command)
+  async deleteSession(sessionName: string): Promise<void> {
+    const filePath = this._getSessionPath(sessionName);
+
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  // Get active session list (for list command)
+  async listSessions(): Promise<SessionInfo[]> {
+    const tmuxSessions = await this._tmux.listSessions();
+    const ccteamSessions = tmuxSessions.filter((session) =>
+      session.startsWith("ccteam-"),
+    );
+
+    await this._cleanupStaleSessions(ccteamSessions);
+
+    const activeSessions: SessionInfo[] = [];
+    for (const sessionName of ccteamSessions) {
+      const sessionInfo = await this._loadSessionInfo(sessionName);
+      if (sessionInfo) {
+        activeSessions.push(sessionInfo);
+      }
+    }
+
+    return activeSessions;
+  }
+
+  // Private methods
+  private _getSessionPath(sessionName: string): string {
+    return path.join(this._sessionsDir, `${sessionName}.json`);
+  }
+
+  private _prepareSessionsDir(): void {
+    if (!fs.existsSync(this._sessionsDir)) {
+      fs.mkdirSync(this._sessionsDir, { recursive: true });
+    }
+  }
+
+  private async _cleanupStaleSessions(tmuxSessions: string[]): Promise<void> {
+    // Check if directory exists first
+    if (!fs.existsSync(this._sessionsDir)) {
+      return;
+    }
+
+    const sessionFiles = fs
+      .readdirSync(this._sessionsDir)
+      .filter((file) => file.endsWith(".json"));
+
+    const staleSessions = sessionFiles.filter((file) => {
+      const sessionName = path.basename(file, ".json");
+      return !tmuxSessions.includes(sessionName);
+    });
+
+    await Promise.all(
+      staleSessions.map((file) =>
+        fs.promises.unlink(path.join(this._sessionsDir, file)).catch(() => {}),
+      ),
+    );
+  }
+
+  // Load session information (internal use)
+  private async _loadSessionInfo(
+    sessionName: string,
+  ): Promise<SessionInfo | null> {
+    const filePath = this._getSessionPath(sessionName);
+
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+
+    const fileContent = fs.readFileSync(filePath, "utf8");
+    const jsonData = JSON.parse(fileContent);
+
+    const result = SessionInfoSchema.safeParse(jsonData);
+    if (!result.success) {
+      // Remove invalid JSON file
+      fs.unlinkSync(filePath);
+      return null;
+    }
+
+    return result.data;
+  }
+}

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -114,15 +114,22 @@ export class SessionManager {
     }
 
     const fileContent = fs.readFileSync(filePath, "utf8");
-    const jsonData = JSON.parse(fileContent);
 
-    const result = SessionInfoSchema.safeParse(jsonData);
-    if (!result.success) {
-      // Remove invalid JSON file
+    try {
+      const jsonData = JSON.parse(fileContent);
+
+      const result = SessionInfoSchema.safeParse(jsonData);
+      if (!result.success) {
+        // Remove invalid JSON file
+        fs.unlinkSync(filePath);
+        return null;
+      }
+
+      return result.data;
+    } catch {
+      // JSON parse error - remove invalid file and return null
       fs.unlinkSync(filePath);
       return null;
     }
-
-    return result.data;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import packageJson from "../package.json" with { type: "json" };
 import { sendCommand } from "./cmd/agent/send";
 import { initCommand } from "./cmd/init";
+import { listCommand } from "./cmd/list";
 import { startCommand } from "./cmd/start";
 import { stopCommand } from "./cmd/stop";
 import { CCTeamError } from "./lib/error";
@@ -79,8 +80,15 @@ program
   .command("stop")
   .description("Stop Claude Code Team session for specified session ID")
   .argument("<session-id>", "The session ID to stop (e.g., ccteam-ABCDE)")
-  .action(async (sessionId, options) => {
-    await stopCommand(sessionId, options);
+  .action(async (sessionId) => {
+    await stopCommand(sessionId);
+  });
+
+program
+  .command("list")
+  .description("List active ccteam sessions")
+  .action(async (options) => {
+    await listCommand(options);
   });
 
 program


### PR DESCRIPTION
## Summary

This PR introduces a new `list` command that enables users to view all active ccteam sessions with comprehensive metadata. The implementation includes persistent session storage, automatic cleanup of stale sessions, and a clean, professional display format.

## Motivation

Previously, users had no straightforward way to:
- View active ccteam sessions
- See when sessions were started
- Identify which directory each session is working in
- Clean up orphaned session data

This feature addresses these needs by providing a comprehensive session management solution.

## Implementation Details

### 1. **SessionManager Class** (`src/lib/session.ts`)
A new self-contained class that handles all session persistence operations:
- **Type-safe schema**: Uses Zod for validation of session data
- **Persistent storage**: Saves session metadata to `~/.ccteam/sessions/<session>.json`
- **CRUD operations**: 
  - `saveSession()`: Stores session info on start
  - `deleteSession()`: Removes session info on stop
  - `listSessions()`: Retrieves all active sessions
- **Automatic cleanup**: Removes orphaned JSON files for terminated sessions
- **Professional code standards**: Private methods prefixed with underscore, English comments throughout

### 2. **List Command** (`src/cmd/list/index.ts`)
The new command that displays active sessions:
- **Clean table format**: Well-aligned columns for easy reading
- **Date formatting**: Uses date-fns for consistent date display (`yyyy-MM-dd HH:mm`)
- **Dynamic width**: Horizontal line adapts to terminal width
- **Informative output**: Shows session name, start time, and working directory
- **User-friendly messages**: Clear feedback when no sessions are active

### 3. **Integration with Existing Commands**
Seamlessly integrated session persistence:
- **start command**: Saves session info immediately after tmux session creation
- **stop command**: Removes session info after termination (with silent error handling)
- **No breaking changes**: Existing functionality remains intact

### 4. **CLI Registration**
Added the new command to the main CLI interface with appropriate description.

## Technical Decisions

1. **File-based persistence**: Chosen for simplicity and reliability
2. **Home directory storage**: `~/.ccteam/sessions/` ensures persistence across working directories
3. **JSON format**: Human-readable and easily parseable
4. **Graceful error handling**: Operations fail silently to avoid disrupting core functionality
5. **Early return optimization**: Performance improvements in cleanup operations

## User Experience

### Before
```bash
# No way to see active sessions
# Had to manually check tmux list-sessions
# No metadata about when/where sessions were started
```

### After
```bash
$ ccteam list
[INFO] Loading ccteam sessions...

SESSION           STARTED AT           WORKING DIRECTORY
────────────────────────────────────────────────────────────────────────────────
ccteam-6LKkH      2025-06-24 06:09     /Users/koki/work/repos/github.com/koki-develop/claude-code-team

Found 1 active session(s)
```

## Testing

- ✅ Manual testing of all commands (start, stop, list)
- ✅ Verified session persistence across restarts
- ✅ Confirmed automatic cleanup of stale sessions
- ✅ Tested with multiple concurrent sessions
- ✅ Type checking passes (`bun run typecheck`)
- ✅ Linting passes (`bun run lint`)

## Future Enhancements

This foundation enables potential future features:
- Session resumption with preserved context
- Session history and analytics
- Advanced filtering and search capabilities
- Session metadata extensions (e.g., task descriptions, tags)

## Breaking Changes

None. This is a purely additive feature that maintains backward compatibility.

## Checklist

- [x] Code follows project conventions
- [x] TypeScript types are properly defined
- [x] Error handling is implemented gracefully
- [x] Comments are in English
- [x] Commit messages follow conventional format
- [x] Pre-commit hooks pass
- [x] Manual testing completed

🤖 Generated with [Claude Code](https://claude.ai/code)